### PR TITLE
Mesh for triangle

### DIFF
--- a/examples/create_triangle.rs
+++ b/examples/create_triangle.rs
@@ -1,0 +1,59 @@
+extern crate bbggez;
+
+use bbggez::Utility;
+use ggez::{
+    event, event::EventHandler, graphics, graphics::Color, nalgebra::Point2, timer, Context,
+    ContextBuilder, GameResult,
+};
+
+struct Game {
+    utility: Utility,
+    color: Color,
+}
+
+impl Game {
+    pub fn new(_context: &mut Context) -> Game {
+        let mut utility = Utility::new();
+
+        Game {
+            utility,
+            color: utility.random_dark_color(),
+        }
+    }
+}
+
+impl EventHandler for Game {
+    fn update(&mut self, context: &mut Context) -> GameResult<()> {
+        if timer::ticks(context) % 1000 == 0 {
+            self.color = self.utility.random_bright_color();
+        }
+
+        Ok(())
+    }
+
+    fn draw(&mut self, context: &mut Context) -> GameResult<()> {
+        graphics::clear(context, graphics::WHITE);
+
+        let (width, height) = graphics::drawable_size(context);
+
+        let triangle = self.utility.create_equilateral_triangle(
+            width/2.0, height/2.0, 300.0, self.color, context,
+        );
+
+        graphics::draw(context, &triangle, (Point2::new(0.0, 0.0),))?;
+
+        graphics::present(context)
+    }
+}
+
+fn main() {
+    let (mut context, mut event_loop) = ContextBuilder::new("Random color example", "Brookzerker")
+        .build()
+        .expect("Game context was not able to be created");
+    let mut game = Game::new(&mut context);
+
+    match event::run(&mut context, &mut event_loop, &mut game) {
+        Ok(_) => println!("Exited cleanly"),
+        Err(error) => println!("Error occured: {}", error),
+    };
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,6 +110,18 @@ impl Utility {
             .unwrap()
     }
 
+    pub fn create_triangle(
+        &mut self,
+        points: &[Point2<f32>; 3],
+        color: Color,
+        ctx: &mut Context,
+    ) -> Mesh {
+        MeshBuilder::new()
+            .polygon(DrawMode::fill(), points, color)
+            .unwrap()
+            .build(ctx)
+            .unwrap()
+    }
     /// Returns a random position that is located within the specified width and height.
     ///
     /// The x value will be in the range [0, `width`), i.e. inclusive of 0 and exclusive of `width`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,11 +3,12 @@ use ggez::{
     event,
     event::EventHandler,
     graphics::{Color, DrawMode, Mesh, MeshBuilder, Rect},
-    nalgebra::{Point2, Vector2},
+    nalgebra::{Point2, Vector2, Translation2, Rotation2},
     Context, ContextBuilder,
 };
 use palette::{Hsl, LinSrgb};
 use rand::prelude::*;
+use std::f32::consts::FRAC_PI_3;
 
 pub extern crate ggez;
 extern crate palette;
@@ -122,6 +123,18 @@ impl Utility {
             .build(ctx)
             .unwrap()
     }
+
+    fn get_equilateral_points(x: f32, y: f32, side: f32) -> [Point2<f32>; 3] {
+        let radius : f32 = side/(3.0 as f32).sqrt();
+        let point = Point2::new(0.0, 0.0 - radius);
+        let translation = Translation2::new(x, y);
+        [translation*point, translation*(Rotation2::new(2.0*FRAC_PI_3)*point), translation*(Rotation2::new(4.0*FRAC_PI_3)*point)]
+    }
+
+    pub fn create_equilateral_triangle(&mut self, x: f32, y: f32, side: f32, color: Color, ctx: &mut Context) -> Mesh {
+        Utility::create_triangle(self, &Utility::get_equilateral_points(x, y, side), color, ctx)
+    }
+
     /// Returns a random position that is located within the specified width and height.
     ///
     /// The x value will be in the range [0, `width`), i.e. inclusive of 0 and exclusive of `width`.


### PR DESCRIPTION
You can get a mesh for a triangle by passing a slice of 3 points to the `create_triangle` function. The points have to be in clockwise order as we are using the polygon function to create the mesh.

To get a mesh for an equilateral triangle, we give the function `create_equilateral_triangle` the centroid coordinates and the size of the side. The `get_equilateral_points` is used to calculate the 3 equidistant vertices of the triangle. 